### PR TITLE
Add schemars feature to derive JsonSchema on all types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ builder = ["derive_builder"]
 
 [dependencies]
 derive_builder = { version = "^0.12", optional = true }
+schemars = { version = "0.8.15", optional = true }
 serde = { version = "^1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! ## Features
 //! - `serde`: \[Default\] Add serde support
 //! - `derive_builder` Enable the derive_builder crate for an automatically generated builder pattern API
+//! - `schemars`: Enable the schemars crate for generating a JSON schema from the structs
 
 #[cfg(feature = "serde")]
 mod bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ use derive_builder::Builder;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NetplanConfig {
     pub network: NetworkConfig,
 }
@@ -41,6 +42,7 @@ pub struct NetplanConfig {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NetworkConfig {
     pub version: u8,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -74,6 +76,7 @@ pub struct NetworkConfig {
 /// set up a hardware VLAN filter for it. There can be only one defined per VF.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum Renderer {
     #[cfg_attr(feature = "serde", serde(rename = "networkd"))]
     Networkd,
@@ -94,6 +97,7 @@ pub enum Renderer {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 #[cfg_attr(feature = "serde", serde(rename = "lowercase"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum UseDomains {
     Boolean(
         #[cfg_attr(

--- a/src/netplan/authentication.rs
+++ b/src/netplan/authentication.rs
@@ -10,6 +10,7 @@ use derive_builder::Builder;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct AuthConfig {
     /// The supported key management modes are none (no key management);
     /// psk (WPA with pre-shared key, common for home wifi); eap (WPA
@@ -54,6 +55,7 @@ pub struct AuthConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AuthMethod {
     #[cfg_attr(feature = "serde", serde(rename = "tls"))]
     Tls,
@@ -65,6 +67,7 @@ pub enum AuthMethod {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum KeyManagmentMode {
     #[cfg_attr(feature = "serde", serde(rename = "none"))]
     None,

--- a/src/netplan/device_types/bonds.rs
+++ b/src/netplan/device_types/bonds.rs
@@ -10,6 +10,7 @@ use crate::CommonPropertiesAllDevices;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BondConfig {
     /// All devices matching this ID list will be added to the bond.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -31,6 +32,7 @@ pub struct BondConfig {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BondParameters {
     /// Set the bonding mode used for the interfaces. The default is
     /// balance-rr (round robin). Possible values are balance-rr,
@@ -179,6 +181,7 @@ pub struct BondParameters {
 /// balance-tcp and balance-slb are supported.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum BondMode {
     #[cfg_attr(feature = "serde", serde(rename = "balance-rr"))]
     BalanceRr,
@@ -202,6 +205,7 @@ pub enum BondMode {
 /// and fast (every second).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum LacpRate {
     #[cfg_attr(feature = "serde", serde(rename = "slow"))]
     Slow,
@@ -215,6 +219,7 @@ pub enum LacpRate {
 /// encap2+3, and encap3+4.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum TransmitHashPolicy {
     #[cfg_attr(feature = "serde", serde(rename = "layer2"))]
     Layer2,
@@ -233,6 +238,7 @@ pub enum TransmitHashPolicy {
 /// mode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AdSelect {
     #[cfg_attr(feature = "serde", serde(rename = "stable"))]
     Stable,
@@ -247,6 +253,7 @@ pub enum AdSelect {
 /// and all.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ArpValidate {
     #[cfg_attr(feature = "serde", serde(rename = "none"))]
     None,
@@ -264,6 +271,7 @@ pub enum ArpValidate {
 /// enabled. Possible values are any and all.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ArpAllTargets {
     #[cfg_attr(feature = "serde", serde(rename = "any"))]
     Any,
@@ -276,6 +284,7 @@ pub enum ArpAllTargets {
 /// The possible values are none, active, and follow.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum FailOverMacPolicy {
     #[cfg_attr(feature = "serde", serde(rename = "none"))]
     None,
@@ -291,6 +300,7 @@ pub enum FailOverMacPolicy {
 /// possible values are always, better, and failure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum PrimaryReselectPolicy {
     #[cfg_attr(feature = "serde", serde(rename = "always"))]
     Always,

--- a/src/netplan/device_types/bridges.rs
+++ b/src/netplan/device_types/bridges.rs
@@ -10,6 +10,7 @@ use crate::CommonPropertiesAllDevices;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BridgeConfig {
     /// All devices matching this ID list will be added to the bridge. This may
     /// be an empty list, in which case the bridge will be brought online with
@@ -38,6 +39,7 @@ pub struct BridgeConfig {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BridgeParameters {
     /// Set the period of time to keep a MAC address in the forwarding
     /// database after a packet is received. This maps to the AgeingTimeSec=

--- a/src/netplan/device_types/dummy_devices.rs
+++ b/src/netplan/device_types/dummy_devices.rs
@@ -14,6 +14,7 @@ use crate::CommonPropertiesAllDevices;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct DummyDeviceConfig {
     /// Common properties for all devices
     #[cfg_attr(feature = "serde", serde(flatten))]

--- a/src/netplan/device_types/ethernets.rs
+++ b/src/netplan/device_types/ethernets.rs
@@ -10,6 +10,7 @@ use crate::{CommonPropertiesAllDevices, CommonPropertiesPhysicalDeviceType};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct EthernetConfig {
     /// (SR-IOV devices only) The link property declares the device as a
     /// Virtual Function of the selected Physical Function device, as identified
@@ -48,6 +49,7 @@ pub struct EthernetConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum EmbeddedSwitchMode {
     Switchdev,
     Legacy,

--- a/src/netplan/device_types/mod.rs
+++ b/src/netplan/device_types/mod.rs
@@ -46,6 +46,7 @@ use crate::{
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CommonPropertiesAllDevices {
     /// Use the given networking backend for this definition. Currently supported are
     /// networkd and NetworkManager. This property can be specified globally
@@ -248,6 +249,7 @@ pub struct CommonPropertiesAllDevices {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename = "lowercase"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ActivationMode {
     Manual,
     Off,

--- a/src/netplan/device_types/modems.rs
+++ b/src/netplan/device_types/modems.rs
@@ -12,6 +12,7 @@ use crate::{CommonPropertiesAllDevices, CommonPropertiesPhysicalDeviceType};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ModemConfig {
     /// Set the carrier APN (Access Point Name). This can be omitted if
     /// auto-config is enabled.

--- a/src/netplan/device_types/physical.rs
+++ b/src/netplan/device_types/physical.rs
@@ -9,6 +9,7 @@ use derive_builder::Builder;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CommonPropertiesPhysicalDeviceType {
     /// This selects a subset of available physical devices by various hardware
     /// properties. The following configuration will then apply to all matching
@@ -140,6 +141,7 @@ pub struct CommonPropertiesPhysicalDeviceType {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct OpenVSwitchConfig {
     /// Passed-through directly to OpenVSwitch
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -194,6 +196,7 @@ pub struct OpenVSwitchConfig {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SslConfig {
     /// Path to a file containing the CA certificate to be used.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -211,6 +214,7 @@ pub struct SslConfig {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ControllerConfig {
     /// Set the list of addresses to use for the controller targets. The
     /// syntax of these addresses is as defined in ovs-vsctl(8). Example:
@@ -226,6 +230,7 @@ pub struct ControllerConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ConnectionMode {
     InBand,
     OutOfBand,
@@ -233,6 +238,7 @@ pub enum ConnectionMode {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum OpenFlowProtocol {
     OpenFlow10,
     OpenFlow11,
@@ -245,6 +251,7 @@ pub enum OpenFlowProtocol {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum Lacp {
     Active,
     Passive,
@@ -253,6 +260,7 @@ pub enum Lacp {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum FailMode {
     Secure,
     Standalone,
@@ -265,6 +273,7 @@ pub enum FailMode {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MatchConfig {
     /// Current interface name. Globs are supported, and the primary use case
     /// for matching on names, as selecting one fixed name can be more easily

--- a/src/netplan/device_types/tunnels.rs
+++ b/src/netplan/device_types/tunnels.rs
@@ -16,6 +16,7 @@ use crate::CommonPropertiesAllDevices;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct TunnelConfig {
     /// Defines the tunnel mode. Valid options are sit, gre, ip6gre,
     /// ipip, ipip6, ip6ip6, vti, vti6 and wireguard.
@@ -67,6 +68,7 @@ pub struct TunnelConfig {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct WireGuardPeer {
     /// Remote endpoint IPv4/IPv6 address or a hostname, followed by a colon
     /// and a port number.
@@ -96,6 +98,7 @@ pub struct WireGuardPeer {
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct WireGuardPeerKey {
     /// A base64-encoded public key, required for WireGuard peers.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -120,6 +123,7 @@ pub struct WireGuardPeerKey {
 /// mapping, where you can further specify input/output/private.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum TunnelKey {
     Simple(String),
     Complex {
@@ -141,6 +145,7 @@ pub enum TunnelKey {
 /// In addition, the NetworkManager backend supports isatap tunnels.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum TunnelMode {
     #[cfg_attr(feature = "serde", serde(rename = "sit"))]
     Sit,

--- a/src/netplan/device_types/vlans.rs
+++ b/src/netplan/device_types/vlans.rs
@@ -10,6 +10,7 @@ use crate::CommonPropertiesAllDevices;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct VlanConfig {
     /// VLAN ID, a number between 0 and 4094.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]

--- a/src/netplan/device_types/vrfs.rs
+++ b/src/netplan/device_types/vrfs.rs
@@ -16,6 +16,7 @@ use crate::CommonPropertiesAllDevices;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct VrfsConfig {
     /// The numeric routing table identifier. This setting is compulsory.
     pub table: i32,

--- a/src/netplan/device_types/wifis.rs
+++ b/src/netplan/device_types/wifis.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct WifiConfig {
     /// This provides pre-configured connections to NetworkManager. Note that
     /// users can of course select other access points/SSIDs. The keys of the
@@ -39,6 +40,7 @@ pub struct WifiConfig {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct AccessPointConfig {
     /// Enable WPA2 authentication and set the passphrase for it. If neither
     /// this nor an auth block are given, the network is assumed to be
@@ -85,6 +87,7 @@ pub struct AccessPointConfig {
 /// network if unset (the default).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum WirelessBand {
     /// 2.4Ghz
     #[cfg_attr(feature = "serde", serde(rename = "2.4GHz"))]
@@ -100,6 +103,7 @@ pub enum WirelessBand {
 /// ap is only supported with NetworkManager.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AccessPointMode {
     #[cfg_attr(feature = "serde", serde(rename = "infrastructure"))]
     Infrastructure,
@@ -116,6 +120,7 @@ pub enum AccessPointMode {
 /// default flag (the default).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum WakeOnWLan {
     #[cfg_attr(feature = "serde", serde(rename = "any"))]
     Any,

--- a/src/netplan/dhcp.rs
+++ b/src/netplan/dhcp.rs
@@ -23,6 +23,7 @@ use derive_builder::Builder;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct DhcpOverrides {
     /// Default: true. When true, the DNS servers received from the
     /// DHCP server will be used and take precedence over any statically
@@ -115,6 +116,7 @@ pub struct DhcpOverrides {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum Ipv6AddressGeneration {
     #[cfg_attr(feature = "serde", serde(rename = "eui64"))]
     Eui64,
@@ -125,6 +127,7 @@ pub enum Ipv6AddressGeneration {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AddressMapping {
     Simple(String),
     Complex {
@@ -140,6 +143,7 @@ pub enum AddressMapping {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum PreferredLifetime {
     #[cfg_attr(feature = "serde", serde(rename = "forever"))]
     Forever,

--- a/src/netplan/routing.rs
+++ b/src/netplan/routing.rs
@@ -17,6 +17,7 @@ use derive_builder::Builder;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RoutingConfig {
     /// Set a source IP address for traffic going through the route.
     /// (NetworkManager: as of v1.8.0)
@@ -79,6 +80,7 @@ pub struct RoutingConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum RouteType {
     Unicast,
     Anycast,
@@ -98,6 +100,7 @@ pub enum RouteType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum RouteScope {
     Global,
     Link,
@@ -114,6 +117,7 @@ pub enum RouteScope {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RoutingPolicy {
     /// Set a source IP address to match traffic for this policy rule.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -148,6 +152,7 @@ pub struct RoutingPolicy {
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_builder", derive(Builder))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NameserverConfig {
     /// A list of IPv4 or IPv6 addresses
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]


### PR DESCRIPTION
Follow up to #3. This add the optional feature `schemars`, which enables deriving `JsonSchema` from the [`schemars` crate](https://docs.rs/schemars/latest/schemars/) to produce JSON schema from the structs and enums.

I briefly looked into the suggestion of checking against an upstream schema but couldn't find any official source for one. I also believe that could end up being more annoying than useful if the schemas weren't created with the same tools.
