### PR TITLE
Fix ActivationMode lowercase serialization

### DIFF
--- a/src/netplan/device_types/mod.rs
+++ b/src/netplan/device_types/mod.rs
@@ -248,7 +248,7 @@ pub struct CommonPropertiesAllDevices {
 /// Supported officially as of networkd v248+.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename = "lowercase"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ActivationMode {
     Manual,


### PR DESCRIPTION
There seems to be a typo on ActiationMode container attribute.
It should be "rename_all" as the enum variants needs to be serialized in lowercase.

This fixes netplan error:
```
Error in network definition: Value of 'activation-mode' needs to be 'manual' or 'off'
      activation-mode: Off
                       ^
```